### PR TITLE
fix: include redeemed field in LiquidUnstakeRequestResponse

### DIFF
--- a/contracts/staking/src/msg.rs
+++ b/contracts/staking/src/msg.rs
@@ -88,6 +88,7 @@ pub struct StateResponse {
 pub struct LiquidUnstakeRequestResponse {
     pub user: String,
     pub amount: Uint128,
+    pub redeemed: bool,
 }
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
 pub struct BatchResponse {

--- a/contracts/staking/src/query.rs
+++ b/contracts/staking/src/query.rs
@@ -64,6 +64,7 @@ fn batch_to_response(batch: Batch) -> BatchResponse {
             .map(|v| LiquidUnstakeRequestResponse {
                 user: v.1.user.to_string(),
                 amount: v.1.shares,
+                redeemed: v.1.redeemed,
             })
             .collect(),
     }

--- a/contracts/staking/src/tests/query_tests.rs
+++ b/contracts/staking/src/tests/query_tests.rs
@@ -136,12 +136,14 @@ mod query_tests {
                     vec![
                         LiquidUnstakeRequestResponse {
                             user: "alice".to_string(),
-                            amount: Uint128::from(1500u128)
+                            amount: Uint128::from(1500u128),
+                            redeemed: false,
                         },
                         LiquidUnstakeRequestResponse {
                             user: "bob".to_string(),
-                            amount: Uint128::from(500u128)
-                        }
+                            amount: Uint128::from(500u128),
+                            redeemed: false,
+                        },
                     ]
                 )
             }
@@ -217,7 +219,8 @@ mod query_tests {
                         first_batch.requests,
                         vec![LiquidUnstakeRequestResponse {
                             user: "bob".to_string(),
-                            amount: Uint128::from(500u128)
+                            amount: Uint128::from(500u128),
+                            redeemed: false,
                         }]
                     )
                 } else {
@@ -236,7 +239,8 @@ mod query_tests {
                         first_batch.requests,
                         vec![LiquidUnstakeRequestResponse {
                             user: "alice".to_string(),
-                            amount: Uint128::from(1500u128)
+                            amount: Uint128::from(1500u128),
+                            redeemed: false,
                         }]
                     )
                 } else {


### PR DESCRIPTION
Include `redeemed` field from `LiquidUnstakeRequest` in `LiquidUnstakeRequestResponse`.
