### PR TITLE
Fabo/readd batch id to batch submission

### DIFF
--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -163,7 +163,7 @@ pub fn execute(
             let payment = must_pay(&info, &config.liquid_stake_token_denom)?;
             execute_liquid_unstake(deps, env, info, payment)
         }
-        ExecuteMsg::SubmitBatch {} => execute_submit_batch(deps, env, info),
+        ExecuteMsg::SubmitBatch { batch_id } => execute_submit_batch(deps, env, info, batch_id),
         ExecuteMsg::Withdraw { batch_id } => execute_withdraw(deps, env, info, batch_id),
         ExecuteMsg::AddValidator { new_validator } => {
             execute_add_validator(deps, env, info, new_validator)

--- a/contracts/staking/src/msg.rs
+++ b/contracts/staking/src/msg.rs
@@ -36,7 +36,9 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     LiquidStake {},
     LiquidUnstake {},
-    SubmitBatch {},
+    SubmitBatch {
+        batch_id: u64,
+    },
     Withdraw {
         batch_id: u64,
     },

--- a/contracts/staking/src/tests/circuit_breaker_tests.rs
+++ b/contracts/staking/src/tests/circuit_breaker_tests.rs
@@ -99,7 +99,7 @@ mod circuit_breaker_tests {
 
         // submit batch
         env.block.time = env.block.time.plus_seconds(config.batch_period - 1);
-        let msg = ExecuteMsg::SubmitBatch {};
+        let msg = ExecuteMsg::SubmitBatch { batch_id: 1 };
         let info = mock_info(&contract, &[]);
         let res = execute(deps.as_mut(), env.clone(), info, msg.clone());
         assert!(res.is_err());

--- a/contracts/staking/src/tests/query_tests.rs
+++ b/contracts/staking/src/tests/query_tests.rs
@@ -193,7 +193,7 @@ mod query_tests {
         // submit batch
         let config = CONFIG.load(&deps.storage).unwrap();
         env.block.time = env.block.time.plus_seconds(config.batch_period + 1);
-        let submit_batch_msg = ExecuteMsg::SubmitBatch {};
+        let submit_batch_msg = ExecuteMsg::SubmitBatch { batch_id: 1 };
         let contract = env.contract.address.clone().to_string();
         let submit_info = mock_info(&contract, &[]);
         let res = execute(deps.as_mut(), env.clone(), submit_info, submit_batch_msg);
@@ -273,7 +273,7 @@ mod query_tests {
         let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg);
 
         env.block.time = env.block.time.plus_seconds(config.batch_period + 1);
-        let submit_batch_msg = ExecuteMsg::SubmitBatch {};
+        let submit_batch_msg = ExecuteMsg::SubmitBatch { batch_id: 1 };
         let contract = env.contract.address.clone().to_string();
         let submit_info = mock_info(&contract, &[]);
         let res = execute(deps.as_mut(), env.clone(), submit_info, submit_batch_msg);

--- a/contracts/staking/src/tests/submit_batch_tests.rs
+++ b/contracts/staking/src/tests/submit_batch_tests.rs
@@ -19,7 +19,7 @@ mod submit_batch_tests {
 
         // print!("{:?}", msgs);
         env.block.time = env.block.time.plus_seconds(config.batch_period + 1);
-        let msg = ExecuteMsg::SubmitBatch {};
+        let msg = ExecuteMsg::SubmitBatch { batch_id: 1 };
 
         let contract = env.contract.address.clone().to_string();
 
@@ -42,7 +42,7 @@ mod submit_batch_tests {
 
         // batch isnt ready
         env.block.time = env.block.time.plus_seconds(config.batch_period - 1);
-        let msg = ExecuteMsg::SubmitBatch {};
+        let msg = ExecuteMsg::SubmitBatch { batch_id: 1 };
 
         let contract = env.contract.address.clone().to_string();
 

--- a/contracts/staking/src/tests/unstake_tests.rs
+++ b/contracts/staking/src/tests/unstake_tests.rs
@@ -47,7 +47,7 @@ mod staking_tests {
         let config = CONFIG.load(&deps.storage).unwrap();
 
         env.block.time = env.block.time.plus_seconds(config.batch_period + 1);
-        let msg = ExecuteMsg::SubmitBatch {};
+        let msg = ExecuteMsg::SubmitBatch { batch_id: 1 };
         res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
 
         let attrs = res.unwrap().attributes;
@@ -125,7 +125,7 @@ mod staking_tests {
         let config = CONFIG.load(&deps.storage).unwrap();
         env.block.time = env.block.time.plus_seconds(config.batch_period + 1);
 
-        let msg = ExecuteMsg::SubmitBatch {};
+        let msg = ExecuteMsg::SubmitBatch { batch_id: 1 };
         res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         let resp = res.unwrap();
         let attrs = resp.attributes;
@@ -254,7 +254,7 @@ mod staking_tests {
         let config = CONFIG.load(&deps.storage).unwrap();
 
         env.block.time = env.block.time.plus_seconds(config.batch_period + 1);
-        let msg = ExecuteMsg::SubmitBatch {};
+        let msg = ExecuteMsg::SubmitBatch { batch_id: 1 };
         let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         assert!(res.is_err());
 
@@ -311,7 +311,7 @@ mod staking_tests {
         let config = CONFIG.load(&deps.storage).unwrap();
 
         env.block.time = env.block.time.plus_seconds(config.batch_period + 1);
-        let msg = ExecuteMsg::SubmitBatch {};
+        let msg = ExecuteMsg::SubmitBatch { batch_id: 1 };
         let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         assert!(res.is_err());
 


### PR DESCRIPTION
To avoid conflicts between the daemon sending wrong amount of tokens to the wrong unstake batch we readd the id to make sure we send to the right batch.