### PR TITLE
fabo/allow for slippage in mint expect

### DIFF
--- a/contracts/staking/src/execute.rs
+++ b/contracts/staking/src/execute.rs
@@ -139,7 +139,7 @@ pub fn execute_liquid_stake(
     }
     if let Some(expected_mint_amount) = expected_mint_amount {
         ensure!(
-            mint_amount == expected_mint_amount,
+            mint_amount >= expected_mint_amount,
             ContractError::MintAmountMismatch {
                 expected: expected_mint_amount,
                 actual: mint_amount

--- a/contracts/staking/src/tests/stake_tests.rs
+++ b/contracts/staking/src/tests/stake_tests.rs
@@ -227,11 +227,11 @@ mod staking_tests {
 
         let info = mock_info("creator", &coins(1000, NATIVE_TOKEN));
         let msg = ExecuteMsg::LiquidStake {
-            expected_mint_amount: Some(Uint128::from(1_000u128)),
+            expected_mint_amount: Some(Uint128::from(2_000_000u128)),
         };
         let res: Result<cosmwasm_std::Response, ContractError> =
             execute(deps.as_mut(), mock_env(), info.clone(), msg.clone());
-        assert!(res.is_err());
+        assert!(res.is_err()); // minted amount is lower than expected
 
         let msg = ExecuteMsg::LiquidStake {
             expected_mint_amount: Some(Uint128::from(1_000_000u128)),


### PR DESCRIPTION
Before the mint expectations was fixed. Now this allows for some slippage