### PR TITLE
fabo/add mint amount feedback

### DIFF
--- a/contracts/staking/src/execute.rs
+++ b/contracts/staking/src/execute.rs
@@ -173,7 +173,8 @@ pub fn execute_liquid_stake(
         .add_submessage(sub_msg)
         .add_attribute("action", "liquid_stake")
         .add_attribute("sender", info.sender.to_string())
-        .add_attribute("amount", amount))
+        .add_attribute("in_amount", amount)
+        .add_attribute("mint_amount", mint_amount))
 }
 
 pub fn execute_liquid_unstake(

--- a/contracts/staking/src/tests/ibc_transfer_tests.rs
+++ b/contracts/staking/src/tests/ibc_transfer_tests.rs
@@ -42,7 +42,8 @@ mod ibc_transfer_tests {
                     vec![
                         attr("action", "liquid_stake"),
                         attr("sender", "creator"),
-                        attr("amount", "1000")
+                        attr("in_amount", "1000"),
+                        attr("mint_amount", "1000"),
                     ]
                 );
                 assert_eq!(
@@ -184,7 +185,8 @@ mod ibc_transfer_tests {
                     vec![
                         attr("action", "liquid_stake"),
                         attr("sender", "creator"),
-                        attr("amount", "1000")
+                        attr("in_amount", "1000"),
+                        attr("mint_amount", "1000"),
                     ]
                 );
             }
@@ -265,7 +267,8 @@ mod ibc_transfer_tests {
                     vec![
                         attr("action", "liquid_stake"),
                         attr("sender", "creator"),
-                        attr("amount", "1000")
+                        attr("in_amount", "1000"),
+                        attr("mint_amount", "1000"),
                     ]
                 );
             }

--- a/contracts/staking/src/tests/stake_tests.rs
+++ b/contracts/staking/src/tests/stake_tests.rs
@@ -44,7 +44,8 @@ mod staking_tests {
                     vec![
                         attr("action", "liquid_stake"),
                         attr("sender", "creator"),
-                        attr("amount", "1000")
+                        attr("in_amount", "1000"),
+                        attr("mint_amount", "1000"),
                     ]
                 );
                 assert_eq!(result.messages.len(), 2);


### PR DESCRIPTION
adds an attribute to be returned on minting to clarify the amount minted for easier access/displaying