### PR TITLE
fix: fix pagination by using `filter` instead of `take_while`

### DIFF
--- a/contracts/staking/src/helpers.rs
+++ b/contracts/staking/src/helpers.rs
@@ -124,7 +124,7 @@ where
     match limit {
         Some(limit) => Ok(items
             .map(|i| i.unwrap().1)
-            .take_while(|i| {
+            .filter(|i| {
                 if taken >= limit {
                     return false;
                 }
@@ -138,7 +138,7 @@ where
             .collect::<Vec<_>>()),
         None => Ok(items
             .map(|i| i.unwrap().1)
-            .take_while(|i| {
+            .filter(|i| {
                 if let Some(filter) = &filter {
                     filter(&i)
                 } else {

--- a/contracts/staking/src/tests/query_tests.rs
+++ b/contracts/staking/src/tests/query_tests.rs
@@ -269,8 +269,17 @@ mod query_tests {
         };
         bin = query(deps.as_ref(), env.clone(), msg).unwrap();
         result = from_binary::<BatchesResponse>(&bin);
-        let result = result.unwrap();
-        assert_eq!(result.batches.len(), 1);
+        assert_eq!(result.unwrap().batches.len(), 1);
+
+        // query only pending batches - there must always be 1
+        let msg = QueryMsg::Batches {
+            start_after: None,
+            limit: None,
+            status: Some(milky_way::staking::BatchStatus::Pending),
+        };
+        bin = query(deps.as_ref(), env.clone(), msg).unwrap();
+        result = from_binary::<BatchesResponse>(&bin);
+        assert_eq!(result.unwrap().batches.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Fixes pagination issue by using `filter` instead of `take_while` inside `paginate_map`. `take_while` stops the iteration once it sees the first `false` returned from the predicate, unlike `filter`.