### PR TITLE
fabo/force recover ibc txs

### DIFF
--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -231,9 +231,16 @@ pub fn execute(
             total_liquid_stake_token,
             total_reward_amount,
         ),
-        ExecuteMsg::RecoverPendingIbcTransfers { paginated } => {
-            recover(deps, env, info, paginated.unwrap_or(false))
-        }
+        ExecuteMsg::RecoverPendingIbcTransfers {
+            paginated,
+            selected_packets,
+        } => recover(
+            deps,
+            env,
+            info,
+            selected_packets,
+            paginated.unwrap_or(false),
+        ),
         ExecuteMsg::FeeWithdraw { amount } => fee_withdraw(deps, env, info, amount),
     }
 }

--- a/contracts/staking/src/execute.rs
+++ b/contracts/staking/src/execute.rs
@@ -586,11 +586,16 @@ pub fn execute_accept_ownership(
 pub fn recover(
     mut deps: DepsMut,
     env: Env,
-    _info: MessageInfo,
+    info: MessageInfo,
     selected_packets: Option<Vec<u64>>,
     page: bool,
 ) -> Result<Response, ContractError> {
     let page_size = 10;
+
+    // forced recovery is dangerous and should only be done by the admin
+    if selected_packets.is_some() && page {
+        ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
+    }
 
     // timed out and failed packets
     let packets: Vec<IBCTransfer> = if selected_packets.is_some() {

--- a/contracts/staking/src/execute.rs
+++ b/contracts/staking/src/execute.rs
@@ -593,7 +593,7 @@ pub fn recover(
     let page_size = 10;
 
     // forced recovery is dangerous and should only be done by the admin
-    if selected_packets.is_some() && page {
+    if selected_packets.is_some() {
         ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
     }
 

--- a/contracts/staking/src/msg.rs
+++ b/contracts/staking/src/msg.rs
@@ -78,6 +78,7 @@ pub enum ExecuteMsg {
     },
     RecoverPendingIbcTransfers {
         paginated: Option<bool>,
+        selected_packets: Option<Vec<u64>>,
     },
     FeeWithdraw {
         amount: Uint128,

--- a/contracts/staking/src/tests/ibc_transfer_tests.rs
+++ b/contracts/staking/src/tests/ibc_transfer_tests.rs
@@ -4,7 +4,7 @@ mod ibc_transfer_tests {
     use crate::msg::{ExecuteMsg, IBCLifecycleComplete, SudoMsg};
     use crate::query::query_ibc_queue;
     use crate::state::{ibc, IbcWaitingForReply, IBC_WAITING_FOR_REPLY, INFLIGHT_PACKETS};
-    use crate::tests::test_helper::{init, CELESTIA1, CHANNEL_ID, NATIVE_TOKEN, OSMO3};
+    use crate::tests::test_helper::{init, CELESTIA1, CHANNEL_ID, NATIVE_TOKEN, OSMO1, OSMO3};
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cosmwasm_std::{
         attr, coins, Addr, CosmosMsg, IbcTimeout, Reply, ReplyOn, SubMsg, SubMsgResponse,
@@ -403,7 +403,6 @@ mod ibc_transfer_tests {
     #[test]
     fn recover_forced() {
         let mut deps = init();
-        let info = mock_info(OSMO3, &[]);
 
         for i in 1..=15 {
             let res = INFLIGHT_PACKETS.save(
@@ -423,7 +422,12 @@ mod ibc_transfer_tests {
             paginated: Some(true),
             selected_packets: Some(vec![1, 2, 3]),
         };
-        let res = execute(deps.as_mut(), mock_env(), info.clone(), msg);
+        let info = mock_info(OSMO1, &[]);
+        let res = execute(deps.as_mut(), mock_env(), info.clone(), msg.clone());
+        assert!(res.is_err()); // not an admin
+
+        let info = mock_info(OSMO3, &[]);
+        let res = execute(deps.as_mut(), mock_env(), info.clone(), msg.clone());
         assert!(res.is_ok());
         let res = res.unwrap();
         assert_eq!(res.attributes[1], attr("packets", "3"));

--- a/contracts/staking/src/tests/ibc_transfer_tests.rs
+++ b/contracts/staking/src/tests/ibc_transfer_tests.rs
@@ -130,7 +130,10 @@ mod ibc_transfer_tests {
         assert!(res.unwrap().ibc_queue.len() == 1);
 
         // send recover message
-        let msg = ExecuteMsg::RecoverPendingIbcTransfers { paginated: None };
+        let msg = ExecuteMsg::RecoverPendingIbcTransfers {
+            paginated: None,
+            selected_packets: None,
+        };
         let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg);
 
         // still the same
@@ -240,7 +243,10 @@ mod ibc_transfer_tests {
         assert!(res.unwrap().ibc_queue.len() == 1);
 
         // send recover message
-        let msg = ExecuteMsg::RecoverPendingIbcTransfers { paginated: None };
+        let msg = ExecuteMsg::RecoverPendingIbcTransfers {
+            paginated: None,
+            selected_packets: None,
+        };
         let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg);
 
         let inflight_packet = INFLIGHT_PACKETS
@@ -321,7 +327,10 @@ mod ibc_transfer_tests {
         assert!(res.unwrap().ibc_queue.len() == 1);
 
         // send recover message
-        let msg = ExecuteMsg::RecoverPendingIbcTransfers { paginated: None };
+        let msg = ExecuteMsg::RecoverPendingIbcTransfers {
+            paginated: None,
+            selected_packets: None,
+        };
         let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg);
 
         let inflight_packet = INFLIGHT_PACKETS
@@ -352,7 +361,10 @@ mod ibc_transfer_tests {
         }
 
         // send recover message
-        let msg = ExecuteMsg::RecoverPendingIbcTransfers { paginated: None };
+        let msg = ExecuteMsg::RecoverPendingIbcTransfers {
+            paginated: None,
+            selected_packets: None,
+        };
         let res = execute(deps.as_mut(), mock_env(), info.clone(), msg);
         assert!(res.is_ok());
         let res = res.unwrap();
@@ -380,11 +392,41 @@ mod ibc_transfer_tests {
         // send recover message
         let msg = ExecuteMsg::RecoverPendingIbcTransfers {
             paginated: Some(true),
+            selected_packets: None,
         };
         let res = execute(deps.as_mut(), mock_env(), info.clone(), msg);
         assert!(res.is_ok());
         let res = res.unwrap();
         assert_eq!(res.attributes[1], attr("packets", "10"));
+    }
+
+    #[test]
+    fn recover_forced() {
+        let mut deps = init();
+        let info = mock_info(OSMO3, &[]);
+
+        for i in 1..=15 {
+            let res = INFLIGHT_PACKETS.save(
+                &mut deps.storage,
+                i,
+                &ibc::IBCTransfer {
+                    sequence: i.clone(),
+                    amount: 1000,
+                    status: ibc::PacketLifecycleStatus::Sent,
+                },
+            );
+            assert!(res.is_ok());
+        }
+
+        // send recover message
+        let msg = ExecuteMsg::RecoverPendingIbcTransfers {
+            paginated: Some(true),
+            selected_packets: Some(vec![1, 2, 3]),
+        };
+        let res = execute(deps.as_mut(), mock_env(), info.clone(), msg);
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res.attributes[1], attr("packets", "3"));
     }
 
     #[test]
@@ -415,7 +457,10 @@ mod ibc_transfer_tests {
         assert!(res.is_ok());
 
         // send recover message
-        let msg = ExecuteMsg::RecoverPendingIbcTransfers { paginated: None };
+        let msg = ExecuteMsg::RecoverPendingIbcTransfers {
+            paginated: None,
+            selected_packets: None,
+        };
         let res = execute(deps.as_mut(), mock_env(), info.clone(), msg);
         assert!(res.is_ok());
         let res = res.unwrap();
@@ -462,7 +507,10 @@ mod ibc_transfer_tests {
         assert!(res.is_ok());
 
         // send recover message
-        let msg = ExecuteMsg::RecoverPendingIbcTransfers { paginated: None };
+        let msg = ExecuteMsg::RecoverPendingIbcTransfers {
+            paginated: None,
+            selected_packets: None,
+        };
         let res = execute(deps.as_mut(), mock_env(), info.clone(), msg);
         assert!(res.is_ok());
 
@@ -497,7 +545,10 @@ mod ibc_transfer_tests {
         );
 
         // send recover message
-        let msg = ExecuteMsg::RecoverPendingIbcTransfers { paginated: None };
+        let msg = ExecuteMsg::RecoverPendingIbcTransfers {
+            paginated: None,
+            selected_packets: None,
+        };
         let res = execute(deps.as_mut(), mock_env(), info.clone(), msg);
         assert!(res.is_ok());
         let res = res.unwrap();


### PR DESCRIPTION
because of the wrong ack bug txs get stuck in the queue. we need to force recover those transactions or they will be stuck in the contract. forced recovery should only be done by an admin