### PR TITLE
fabo/slimmer version of the unstake requests query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "milky_way"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "staking"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "bech32",
  "bech32-no_std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["contracts/*", "packages/*"]
 
 [workspace.package]
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Decento Labs"]
 edition = "2021"
 rust-version = "1.68.0"

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -5,8 +5,9 @@ use crate::execute::{
 use crate::helpers::validate_addresses;
 use crate::ibc::{receive_ack, receive_timeout};
 use crate::query::{
-    query_all_unstake_requests, query_batch, query_batches, query_config, query_ibc_queue,
-    query_pending_batch, query_reply_queue, query_state, query_unstake_requests,
+    query_all_unstake_requests, query_all_unstake_requests_v2, query_batch, query_batches,
+    query_batches_by_ids, query_config, query_ibc_queue, query_pending_batch, query_reply_queue,
+    query_state, query_unstake_requests,
 };
 use crate::state::{
     Config, MultisigAddressConfig, ProtocolFeeConfig, State, ADMIN, BATCHES, CONFIG,
@@ -264,12 +265,17 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             limit,
             status,
         } => to_binary(&query_batches(deps, start_after, limit, status)?),
+        QueryMsg::BatchesByIds { ids } => to_binary(&query_batches_by_ids(deps, ids)?),
         QueryMsg::PendingBatch {} => to_binary(&query_pending_batch(deps)?),
         QueryMsg::UnstakeRequests { user } => {
             to_binary(&query_unstake_requests(deps, user.into_string())?)
         }
+        // DEPR
         QueryMsg::AllUnstakeRequests { start_after, limit } => {
             to_binary(&query_all_unstake_requests(deps, start_after, limit)?)
+        }
+        QueryMsg::AllUnstakeRequestsV2 { start_after, limit } => {
+            to_binary(&query_all_unstake_requests_v2(deps, start_after, limit)?)
         }
 
         // dev only, depr

--- a/contracts/staking/src/msg.rs
+++ b/contracts/staking/src/msg.rs
@@ -1,5 +1,5 @@
 use crate::state::{
-    ibc::IBCTransfer, IbcWaitingForReply, MultisigAddressConfig, ProtocolFeeConfig,
+    ibc::IBCTransfer, IbcWaitingForReply, MultisigAddressConfig, ProtocolFeeConfig, UnstakeRequest,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Timestamp, Uint128};
@@ -164,12 +164,19 @@ pub enum QueryMsg {
         limit: Option<u32>,
         status: Option<BatchStatus>,
     },
+    #[returns(BatchesResponse)]
+    BatchesByIds { ids: Vec<u64> },
     #[returns(BatchResponse)]
     PendingBatch {},
-    #[returns(Vec<UnstakeRequestResponse>)]
+    #[returns(Vec<UnstakeRequest>)]
     UnstakeRequests { user: Addr },
     #[returns(Vec<UnstakeRequestResponse>)]
     AllUnstakeRequests {
+        start_after: Option<u64>,
+        limit: Option<u32>,
+    },
+    #[returns(Vec<(String, u64, Uint128)>)]
+    AllUnstakeRequestsV2 {
         start_after: Option<u64>,
         limit: Option<u32>,
     },

--- a/contracts/staking/src/tests/unstake_tests.rs
+++ b/contracts/staking/src/tests/unstake_tests.rs
@@ -8,6 +8,7 @@ mod staking_tests {
     use crate::msg::UnstakeRequestResponse;
     use crate::state::new_unstake_request;
     use crate::state::unstake_requests;
+    use crate::state::UnstakeRequest;
     use crate::state::{Config, BATCHES, CONFIG, STATE};
     use crate::tests::test_helper::init;
     use cosmwasm_std::from_binary;
@@ -104,13 +105,13 @@ mod staking_tests {
         );
 
         // Check unstake requests
-        let msg = QueryMsg::AllUnstakeRequests {
+        let msg = QueryMsg::AllUnstakeRequestsV2 {
             start_after: None,
             limit: None,
         };
         let res = query(deps.as_ref(), mock_env(), msg);
         assert!(res.is_ok());
-        let unstake_requests_records: Vec<UnstakeRequestResponse> =
+        let unstake_requests_records: Vec<(String, u64, Uint128)> =
             from_binary(&res.unwrap()).unwrap();
 
         assert!(unstake_requests_records.len() == 2); //for bob & alice
@@ -118,17 +119,17 @@ mod staking_tests {
         assert_eq!(
             unstake_requests_records
                 .iter()
-                .find(|v| v.user == "bob")
+                .find(|v| v.0 == "bob")
                 .unwrap()
-                .unstake_amount,
+                .2,
             Uint128::from(1500u128)
         );
         assert_eq!(
             unstake_requests_records
                 .iter()
-                .find(|v| v.user == "alice")
+                .find(|v| v.0 == "alice")
                 .unwrap()
-                .unstake_amount,
+                .2,
             Uint128::from(5000u128)
         );
 
@@ -398,7 +399,7 @@ mod staking_tests {
         );
         assert!(unstake_requests_res.is_ok());
         let unstake_requests_res =
-            from_binary::<Vec<UnstakeRequestResponse>>(&unstake_requests_res.unwrap());
+            from_binary::<Vec<UnstakeRequest>>(&unstake_requests_res.unwrap());
         assert!(unstake_requests_res.is_ok());
         let unstake_requests = unstake_requests_res.unwrap();
         assert_eq!(unstake_requests.len(), 2);
@@ -439,16 +440,9 @@ mod staking_tests {
         );
         assert!(unstake_requests_res.is_ok());
         let unstake_requests_res =
-            from_binary::<Vec<UnstakeRequestResponse>>(&unstake_requests_res.unwrap());
+            from_binary::<Vec<UnstakeRequest>>(&unstake_requests_res.unwrap());
         assert!(unstake_requests_res.is_ok());
         let unstake_requests = unstake_requests_res.unwrap();
-        assert_eq!(
-            unstake_requests
-                .iter()
-                .filter(|v| v.status == "received")
-                .count(),
-            1
-        );
         assert_eq!(unstake_requests.get(0).unwrap().batch_id, 1);
     }
 }


### PR DESCRIPTION
the records can be a lot so reducing the data schema around them that get submitted over http seems to be a good idea