### PR TITLE
fix: update oracle price after contract resume

### DIFF
--- a/contracts/staking/src/execute.rs
+++ b/contracts/staking/src/execute.rs
@@ -923,19 +923,20 @@ pub fn resume_contract(
     ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
 
     let mut config: Config = CONFIG.load(deps.storage)?;
-
     config.stopped = false;
     CONFIG.save(deps.storage, &config)?;
 
-    let mut state: State = STATE.load(deps.storage)?;
-
-    state.total_native_token = total_native_token;
-    state.total_liquid_stake_token = total_liquid_stake_token;
-    state.total_reward_amount = total_reward_amount;
+    STATE.update(
+        deps.storage,
+        |mut state| -> Result<State, cosmwasm_std::StdError> {
+            state.total_native_token = total_native_token;
+            state.total_liquid_stake_token = total_liquid_stake_token;
+            state.total_reward_amount = total_reward_amount;
+            Ok(state)
+        },
+    )?;
 
     let update_oracle_msgs = update_oracle_msgs(deps.as_ref(), env, &config)?;
-
-    STATE.save(deps.storage, &state)?;
 
     Ok(Response::new()
         .add_attribute("action", "resume_contract")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Overview

This PR fixes a bug where we send the wrong redeemption rate to the oracle when the contract is resumed.
This is caused by the fact that `update_oracle_msgs` internally uses the contract `STATE` to compute the redemption rate but during the contract resume logic the state is written after the invocation of `update_oracle_msgs` causing the contract to send the wrong redemptio rate to the oracle contract.
 
closes: #XXXX

## What changes have been made in this PR?

- [ ]

## Checklist

---

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation
