### PR TITLE
fix: dedup packets when recovering ibc transfers

### DIFF
--- a/contracts/staking/src/execute.rs
+++ b/contracts/staking/src/execute.rs
@@ -1,7 +1,7 @@
 use crate::contract::IBC_TIMEOUT;
 use crate::error::{ContractError, ContractResult};
 use crate::helpers::{
-    compute_mint_amount, compute_unbond_amount, derive_intermediate_sender, get_rates,
+    compute_mint_amount, compute_unbond_amount, dedup_vec, derive_intermediate_sender, get_rates,
     paginate_map, validate_address, validate_addresses,
 };
 use crate::oracle::Oracle;
@@ -699,7 +699,7 @@ pub fn recover(
 
     // timed out and failed packets
     let packets: Vec<IBCTransfer> = if selected_packets.is_some() {
-        let selected_packets = selected_packets.unwrap();
+        let selected_packets = dedup_vec(selected_packets.unwrap());
         let mut packets: Vec<IBCTransfer> = vec![];
         for packet_id in selected_packets {
             let packet = INFLIGHT_PACKETS.load(deps.storage, packet_id)?;

--- a/contracts/staking/src/helpers.rs
+++ b/contracts/staking/src/helpers.rs
@@ -225,6 +225,20 @@ pub fn validate_ibc_denom(ibc_denom: impl Into<String>) -> StdResult<String> {
     }
 }
 
+/// Removes duplicate elements from the provided vector.
+/// Note: The order of elements in the input vector is not preserved.
+pub fn dedup_vec<T>(mut vec: Vec<T>) -> Vec<T>
+where
+    T: std::hash::Hash + std::cmp::Eq,
+{
+    if vec.is_empty() {
+        return vec;
+    }
+
+    let mut set: HashSet<_> = vec.drain(0..).collect();
+    set.drain().collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Overview

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

## What changes have been made in this PR?

- [ ]

## Checklist

---

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation
