### PR TITLE
feat: add query to get the current contract admin

### DIFF
--- a/contracts/staking/README.md
+++ b/contracts/staking/README.md
@@ -245,6 +245,10 @@ pub enum QueryMsg {
         /// Maximum number of IBC reply queue entries to return.
         limit: Option<u32>,
     },
+
+    /// Queries the current admin.
+    #[returns(AdminResponse)]
+    Admin {},
 }
 ```
 
@@ -471,5 +475,14 @@ pub enum QueryMsg {
       "receiver": "cosmos1j9ns0wkcj2nsym06s9eq4y9kqpx57zz72uc46e"
     }
   ]
+}
+```
+
+
+### Admin
+
+```json
+{
+  "admin": "cosmos1j9ns0wkcj2nsym06s9eq4y9kqpx57zz72uc46e"
 }
 ```

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -6,8 +6,9 @@ use crate::helpers::validate_denom;
 use crate::ibc::{receive_ack, receive_timeout};
 use crate::migrations;
 use crate::query::{
-    query_all_unstake_requests, query_batch, query_batches, query_batches_by_ids, query_config,
-    query_ibc_queue, query_pending_batch, query_reply_queue, query_state, query_unstake_requests,
+    query_admin, query_all_unstake_requests, query_batch, query_batches, query_batches_by_ids,
+    query_config, query_ibc_queue, query_pending_batch, query_reply_queue, query_state,
+    query_unstake_requests,
 };
 use crate::state::{
     assert_not_migrating, Config, State, ADMIN, BATCHES, CONFIG, IBC_WAITING_FOR_REPLY, MIGRATING,
@@ -260,6 +261,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::IbcReplyQueue { start_after, limit } => {
             to_json_binary(&query_reply_queue(deps, start_after, limit)?)
         }
+        QueryMsg::Admin {} => to_json_binary(&query_admin(deps)?),
     }
 }
 

--- a/contracts/staking/src/msg.rs
+++ b/contracts/staking/src/msg.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Timestamp, Uint128};
+use cw_controllers::AdminResponse;
 use milky_way::staking::BatchStatus;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -295,6 +296,10 @@ pub enum QueryMsg {
         /// Maximum number of IBC reply queue entries to return.
         limit: Option<u32>,
     },
+
+    /// Queries the current admin.
+    #[returns(AdminResponse)]
+    Admin {},
 }
 
 #[cw_serde]

--- a/contracts/staking/src/query.rs
+++ b/contracts/staking/src/query.rs
@@ -5,10 +5,11 @@ use crate::msg::{
 };
 use crate::state::ibc::IBCTransfer;
 use crate::state::{
-    unstake_requests, UnstakeRequest, BATCHES, CONFIG, IBC_WAITING_FOR_REPLY, INFLIGHT_PACKETS,
-    PENDING_BATCH_ID, STATE,
+    unstake_requests, UnstakeRequest, ADMIN, BATCHES, CONFIG, IBC_WAITING_FOR_REPLY,
+    INFLIGHT_PACKETS, PENDING_BATCH_ID, STATE,
 };
 use cosmwasm_std::{Deps, StdResult, Timestamp, Uint128};
+use cw_controllers::AdminResponse;
 use cw_storage_plus::Bound;
 use milky_way::staking::{Batch, BatchStatus};
 
@@ -195,4 +196,8 @@ pub fn query_all_unstake_requests(
         .collect();
 
     Ok(unstaking_requests)
+}
+
+pub fn query_admin(deps: Deps) -> StdResult<AdminResponse> {
+    ADMIN.query_admin(deps)
 }

--- a/contracts/staking/src/tests/query_tests.rs
+++ b/contracts/staking/src/tests/query_tests.rs
@@ -2,10 +2,10 @@ use crate::contract::{execute, query};
 use crate::msg::{
     BatchResponse, BatchesResponse, ConfigResponse, ExecuteMsg, QueryMsg, StateResponse,
 };
-use crate::query::query_pending_batch;
+use crate::query::{query_admin, query_pending_batch};
 use crate::state::{CONFIG, STATE};
 use crate::tests::test_helper::{
-    init, CELESTIA2, CELESTIAVAL1, CELESTIAVAL2, CHANNEL_ID, LIQUID_STAKE_TOKEN_DENOM,
+    init, ADMIN, CELESTIA2, CELESTIAVAL1, CELESTIAVAL2, CHANNEL_ID, LIQUID_STAKE_TOKEN_DENOM,
     NATIVE_TOKEN, OSMO2, OSMO3, OSMO4, STAKER_ADDRESS,
 };
 use cosmwasm_std::testing::{mock_env, mock_info};
@@ -325,4 +325,13 @@ fn get_pending_batch() {
 
     let pending_batch_id = query_pending_batch(deps.as_ref());
     assert!(pending_batch_id.unwrap().id == 2);
+}
+
+#[test]
+fn get_admin() {
+    let mut deps = init();
+    let mut env = mock_env();
+
+    let admin_respone = query_admin(deps.as_ref()).unwrap();
+    assert_eq!(ADMIN, admin_respone.admin.unwrap().as_str())
 }

--- a/contracts/staking/src/tests/query_tests.rs
+++ b/contracts/staking/src/tests/query_tests.rs
@@ -329,9 +329,9 @@ fn get_pending_batch() {
 
 #[test]
 fn get_admin() {
-    let mut deps = init();
-    let mut env = mock_env();
+    let deps = init();
+    let env = mock_env();
 
-    let admin_respone = query_admin(deps.as_ref()).unwrap();
-    assert_eq!(ADMIN, admin_respone.admin.unwrap().as_str())
+    let admin_response = query_admin(deps.as_ref()).unwrap();
+    assert_eq!(ADMIN, admin_response.admin.unwrap().as_str())
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Overview

This PR adds a new query message `admin` to obtain the current staking contract admin.

closes: LST-126


## What changes have been made in this PR?

- [ ]

## Checklist

---

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation
