### PR TITLE
feat(staking): improve contract initializtion

### DIFF
--- a/contracts/staking/README.md
+++ b/contracts/staking/README.md
@@ -26,6 +26,13 @@ pub struct InstantiateMsg {
 
     /// Set of addresses allowed to trigger a circuit break.
     pub monitors: Vec<String>,
+
+    /// Optional admin account.
+    pub admin: Option<String>,
+
+    /// Optional oracle contract code ID that will be instantiated if
+    /// it is `Some` and the `protocol_chain_config.oracle_address` is `None`.
+    pub oracle_code_id: Option<u64>,
 }
 ```
 

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -379,13 +379,16 @@ pub fn reply(deps: DepsMut, _env: Env, reply: Reply) -> Result<Response, Contrac
     assert_not_migrating(deps.as_ref())?;
 
     if reply.id == INSTANTIATE_ORACLE_CONTRACT_REPLY_ID {
-        // Parse the
+        // Parse the contract instantiate replay
         let instantiate_reply = cw_utils::parse_reply_instantiate_data(reply)
             .map_err(|_| ContractError::InstantiateOracleFailed {})?;
 
+        // Get the instantiated contract address
         let contract_addr = deps
             .api
             .addr_validate(&instantiate_reply.contract_address)?;
+
+        // Store the instantiated oracle contract address
         CONFIG.update::<_, StdError>(deps.storage, |mut config| {
             config.protocol_chain_config.oracle_address = Some(contract_addr);
             Ok(config)

--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -117,7 +117,7 @@ pub fn instantiate(
         if config.protocol_chain_config.oracle_address.is_none() && msg.oracle_code_id.is_some() {
             Some(SubMsg::reply_on_success(
                 wasm_instantiate(
-                    1,
+                    msg.oracle_code_id.unwrap(),
                     &OracleInstantiateMsg {
                         admin_address: env.contract.address.to_string(),
                     },

--- a/contracts/staking/src/error.rs
+++ b/contracts/staking/src/error.rs
@@ -174,4 +174,7 @@ pub enum ContractError {
         value: Uint128,
         max: Uint128,
     },
+
+    #[error("Oracle contract instantiation failed")]
+    InstantiateOracleFailed {},
 }

--- a/contracts/staking/src/execute.rs
+++ b/contracts/staking/src/execute.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use crate::contract::IBC_TIMEOUT;
 use crate::error::{ContractError, ContractResult};
 use crate::helpers::{
-    compute_mint_amount, compute_unbond_amount, dedup_vec, derive_intermediate_sender, get_rates,
-    paginate_map, validate_ibc_denom,
+    compute_mint_amount, compute_unbond_amount, dedup_vec, get_rates, paginate_map,
+    validate_ibc_denom,
 };
 use crate::oracle::Oracle;
 use crate::state::{

--- a/contracts/staking/src/migrations/v1_2_0.rs
+++ b/contracts/staking/src/migrations/v1_2_0.rs
@@ -1,16 +1,11 @@
-use crate::{
-    contract::CONTRACT_NAME,
-    error::ContractResult,
-    state::{CONFIG, STATE},
-    tokenfactory,
-};
-use cosmwasm_std::{DepsMut, Env, Response, Uint128};
+use crate::{contract::CONTRACT_NAME, error::ContractResult};
+use cosmwasm_std::{DepsMut, Env, Response};
 use cw2::{assert_contract_version, set_contract_version};
 
 const FROM_VERSION: &str = "1.1.0";
 const TO_VERSION: &str = "1.2.0";
 
-pub fn migrate(deps: DepsMut, env: Env) -> ContractResult<Response> {
+pub fn migrate(deps: DepsMut, _env: Env) -> ContractResult<Response> {
     assert_contract_version(deps.storage, CONTRACT_NAME, FROM_VERSION)?;
     set_contract_version(deps.storage, CONTRACT_NAME, TO_VERSION)?;
 

--- a/contracts/staking/src/msg.rs
+++ b/contracts/staking/src/msg.rs
@@ -1,7 +1,7 @@
 use crate::{
     state::{
         ibc::IBCTransfer, IbcWaitingForReply, NativeChainConfig, ProtocolChainConfig,
-        ProtocolFeeConfig, UnstakeRequest,
+        ProtocolFeeConfig,
     },
     types::{
         BatchExpectedAmount, UnsafeNativeChainConfig, UnsafeProtocolChainConfig,
@@ -10,7 +10,6 @@ use crate::{
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Timestamp, Uint128};
-use cw_controllers::AdminResponse;
 use milky_way::staking::BatchStatus;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -268,7 +267,7 @@ pub enum QueryMsg {
     PendingBatch {},
 
     /// Queries the unstake requests made by a specific user.
-    #[returns(Vec<UnstakeRequest>)]
+    #[returns(Vec<crate::state::UnstakeRequest>)]
     UnstakeRequests {
         /// Address of the user whose unstake requests are to be queried.
         user: Addr,
@@ -304,7 +303,7 @@ pub enum QueryMsg {
     },
 
     /// Queries the current admin.
-    #[returns(AdminResponse)]
+    #[returns(cw_controllers::AdminResponse)]
     Admin {},
 }
 

--- a/contracts/staking/src/msg.rs
+++ b/contracts/staking/src/msg.rs
@@ -35,7 +35,13 @@ pub struct InstantiateMsg {
 
     /// Set of addresses allowed to trigger a circuit break.
     pub monitors: Vec<String>,
+
+    /// Optional admin account.
     pub admin: Option<String>,
+
+    /// Optional oracle contract code id that will be instantiated if
+    /// is Some and the protocol_chain_config.oracle_address is None.
+    pub oracle_code_id: Option<u64>,
 }
 
 #[cw_serde]

--- a/contracts/staking/src/msg.rs
+++ b/contracts/staking/src/msg.rs
@@ -39,8 +39,8 @@ pub struct InstantiateMsg {
     /// Optional admin account.
     pub admin: Option<String>,
 
-    /// Optional oracle contract code id that will be instantiated if
-    /// is Some and the protocol_chain_config.oracle_address is None.
+    /// Optional oracle contract code ID that will be instantiated if
+    /// it is `Some` and the `protocol_chain_config.oracle_address` is `None`.
     pub oracle_code_id: Option<u64>,
 }
 

--- a/contracts/staking/src/oracle.rs
+++ b/contracts/staking/src/oracle.rs
@@ -9,3 +9,10 @@ pub enum Oracle {
         redemption_rate: String,
     },
 }
+
+
+#[cw_serde]
+pub struct OracleInstantiateMsg {
+    pub admin_address: String,
+}
+

--- a/contracts/staking/src/oracle.rs
+++ b/contracts/staking/src/oracle.rs
@@ -10,9 +10,7 @@ pub enum Oracle {
     },
 }
 
-
 #[cw_serde]
 pub struct OracleInstantiateMsg {
     pub admin_address: String,
 }
-

--- a/contracts/staking/src/state.rs
+++ b/contracts/staking/src/state.rs
@@ -122,7 +122,7 @@ pub struct UnstakeRequestIndexes<'a> {
     pub by_user: UniqueIndex<'a, (String, u64), UnstakeRequest>,
 }
 
-impl<'a> IndexList<UnstakeRequest> for UnstakeRequestIndexes<'a> {
+impl IndexList<UnstakeRequest> for UnstakeRequestIndexes<'_> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<UnstakeRequest>> + '_> {
         let v: Vec<&dyn Index<UnstakeRequest>> = vec![&self.by_user];
         Box::new(v.into_iter())

--- a/contracts/staking/src/tests/test_helper.rs
+++ b/contracts/staking/src/tests/test_helper.rs
@@ -50,6 +50,7 @@ pub fn mock_init_msg() -> InstantiateMsg {
             treasury_address: Some(OSMO1.to_string()),
         },
         admin: None,
+        oracle_code_id: None,
     }
 }
 

--- a/scripts/testnet/init-stake-contract.sh
+++ b/scripts/testnet/init-stake-contract.sh
@@ -74,26 +74,16 @@ echo ""
 # Contracts initialization
 
 echo "Init treasury contract"
-INIT="{\"trader\":\"$OSMOSIS_TRADER\",\"allowed_swap_routes\":[[{\"pool_id\":1,\"token_in_denom\":\"$NATIVE_TOKEN_DENOM\",\"token_out_denom\":\"uosmo\"}]]}" \
+INIT="{\"trader\":\"$OSMOSIS_TRADER\",\"allowed_swap_routes\":[],\"native_chain_config\":{\"account_address_prefix\":\"celestia\"},\"protocol_chain_config\":{\"account_address_prefix\":\"celestia\"}}" \
 TREASURY_CONTRACT=$(init_contract "$TREASURY_CODE_ID" "$INIT" "Treasury")
 
 echo "Init staking contract"
-INIT="{\"native_chain_config\":{\"account_address_prefix\":\"celestia\",\"validator_address_prefix\":\"celestiavaloper\",\"token_denom\":\"utia\",\"validators\":[\"$CELESTIA_VALIDATOR_1\"],\"unbonding_period\":$UNBONDING_PERIOD,\"staker_address\":\"$CELESTIA_STAKER\",\"reward_collector_address\":\"$CELESTIA_REWARDS_COLLECTOR\"},\"protocol_chain_config\":{\"account_address_prefix\":\"osmo\",\"ibc_token_denom\":\"$NATIVE_TOKEN_DENOM\",\"ibc_channel_id\":\"channel-0\",\"minimum_liquid_stake_amount\":\"100\"},\"protocol_fee_config\":{\"dao_treasury_fee\":\"800\",\"treasury_address\":\"$TREASURY_CONTRACT\"},\"liquid_stake_token_denom\":\"milkTIA\",\"batch_period\":60,\"monitors\":[\"$OSMOSIS_ACCOUNT\"]}"
+INIT="{\"native_chain_config\":{\"account_address_prefix\":\"celestia\",\"validator_address_prefix\":\"celestiavaloper\",\"token_denom\":\"utia\",\"validators\":[\"$CELESTIA_VALIDATOR_1\"],\"unbonding_period\":$UNBONDING_PERIOD,\"staker_address\":\"$CELESTIA_STAKER\",\"reward_collector_address\":\"$CELESTIA_REWARDS_COLLECTOR\"},\"protocol_chain_config\":{\"account_address_prefix\":\"osmo\",\"ibc_token_denom\":\"$NATIVE_TOKEN_DENOM\",\"ibc_channel_id\":\"channel-0\",\"minimum_liquid_stake_amount\":\"100\"},\"protocol_fee_config\":{\"dao_treasury_fee\":\"800\",\"treasury_address\":\"$TREASURY_CONTRACT\"},\"liquid_stake_token_denom\":\"milkTIA\",\"batch_period\":60,\"monitors\":[\"$OSMOSIS_ACCOUNT\"],\"oracle_code_id\":$ORACLE_CODE_ID}"
 STAKE_CONTRACT=$(init_contract "$STAKING_CONTRACT_CODE_ID" "$INIT" "Staking")
 #VALIDATORS=$(osmosisd query staking validators --output json | jq -r '.validators | map(.operator_address) | join(",")')
 
-# Init our oracle contract
-echo "Init oracle contract"
-INIT="{\"admin_address\":\"$STAKE_CONTRACT\"}"
-ORACLE_CONTRACT=$(init_contract "$ORACLE_CODE_ID" "$INIT" "Oracle")
-
 # Start the staking contract
 echo "Starting the staking contract..."
-UPDATE_CONFIG="{\"update_config\":{\"protocol_chain_config\":{\"account_address_prefix\":\"osmo\",\"ibc_token_denom\":\"$NATIVE_TOKEN_DENOM\",\"ibc_channel_id\":\"channel-0\",\"minimum_liquid_stake_amount\":\"100\",\"oracle_address\":\"$ORACLE_CONTRACT\"}}}"
-wait_tx osmosisd tx wasm execute "$STAKE_CONTRACT" "$UPDATE_CONFIG" \
-    --from test_master --keyring-backend test \
-    "$OSMOSIS_TX_PARAMS"
-
 wait_tx osmosisd tx wasm execute "$STAKE_CONTRACT" '{"resume_contract":{"total_native_token":"0","total_liquid_stake_token":"0","total_reward_amount":"0"}}' \
     --from test_master --keyring-backend test \
     "$OSMOSIS_TX_PARAMS"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Overview

This PR aims to reduce the number of transactions required to deploy the `staking` contract. Since the `oracle` contract requires the `admin_address` to be the `staking` contract, we need to know the `staking` contract address in order to initialize the `oracle` contract.

This PR allows specifying the code ID of the `oracle` contract so that both contracts can be initialized with a single `instantiate` transaction.

Closes: LSTS-118

## What changes have been made in this PR?

- [ ]

## Checklist

---

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation
